### PR TITLE
Add py.typed file per PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
                         else ''),
     packages=list(list_packages()),
     package_data={
-        '': ['*.pyi']
+        '': ['*.pyi', 'py.typed']
     },
     install_requires=['pyspark>=2.3.0<2.4.0']
 )


### PR DESCRIPTION
PEP 561 requires a `py.typed` file in packages to indicate that a package supports type checking.
This PR simply adds such a file and distributes it as package data alongside the `*.pyi` files.

https://www.python.org/dev/peps/pep-0561/#packaging-type-information