### PR TITLE
Limit test versions to Python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ install:
   - pip install .
 
 script:
-  - ./tests/mypy_test.py
+  - ./tests/mypy_test.py -p 3.6 3.7
   - MYPY_TEST_PREFIX=$PWD MYPYPATH=$PWD/third_party/3 pytest


### PR DESCRIPTION
This PR limits mypy test versions to 3.6 and above.

__Rationale__

At this point 3.4 and 3.5 are already pretty old (3.4 has been already retired) and typing functions available for these versions are quite limited.
