### PR TITLE
Mark package as partial

### DIFF
--- a/third_party/3/pyspark/py.typed
+++ b/third_party/3/pyspark/py.typed
@@ -1,0 +1,1 @@
+partial


### PR DESCRIPTION
According to [PEP 561](https://www.python.org/dev/peps/pep-0561/#id21)

> If a stub package is partial it MUST include partial\n in a top level py.typed file.

Technically speaking this package is partial, as we omit some of the internal modules. Due to specifics of the installation process it shouldn't matter now, as `partial`

> can be thought of as the functional equivalent of copying the stub package into the same directory as the corresponding runtime package or typeshed folder and type checking the combined directory structure. 

but let's be consistent. 