### PR TITLE
Disable travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 sudo: false
 language: python
 python: 3.7
-cache: pip
+# cache: pip
 before_install:
 - pip install -r requirements-tests-py3.txt
 install:


### PR DESCRIPTION
Temporarily disable Travis pip cache.

It makes sense for stable releases, but for dev it keeps caching (packing and uploading) archive every time and is just much slower.