### PR TITLE
#397: Adapting tests and error messages for readWriterOptions

### DIFF
--- a/test-data/unit/sql-session.test
+++ b/test-data/unit/sql-session.test
@@ -83,16 +83,16 @@ from pyspark.sql import SparkSession
 
 spark = SparkSession.builder.getOrCreate()
 
-spark.read.option("foo", True).option("foo", 1).option("foo", 1.0).option("foo", "1")
-spark.readStream.option("foo", True).option("foo", 1).option("foo", 1.0).option("foo", "1")
+spark.read.option("foo", True).option("foo", 1).option("foo", 1.0).option("foo", "1").option("foo", None)
+spark.readStream.option("foo", True).option("foo", 1).option("foo", 1.0).option("foo", "1").option("foo", None)
 
-spark.read.options(foo=True, bar=1).options(foo=1.0, bar="1")
-spark.readStream.options(foo=True, bar=1).options(foo=1.0, bar="1")
+spark.read.options(foo=True, bar=1).options(foo=1.0, bar="1", baz=None)
+spark.readStream.options(foo=True, bar=1).options(foo=1.0, bar="1", baz=None)
 
 spark.read.load(foo=True)
 spark.readStream.load(foo=True)
 
-spark.read.load(foo=["a"])  # E: Argument "foo" to "load" of "DataFrameReader" has incompatible type "List[str]"; expected "Union[bool, float, int, str]"
-spark.read.option("foo", (1, ))  # E: Argument 2 to "option" of "DataFrameReader" has incompatible type "Tuple[int]"; expected "Union[bool, float, int, str]"
-spark.read.options(bar={1})  # E: Argument "bar" to "options" of "DataFrameReader" has incompatible type "Set[int]"; expected "Union[bool, float, int, str]"
+spark.read.load(foo=["a"])  # E: Argument "foo" to "load" of "DataFrameReader" has incompatible type "List[str]"; expected "Union[bool, float, int, str, None]"
+spark.read.option("foo", (1, ))  # E: Argument 2 to "option" of "DataFrameReader" has incompatible type "Tuple[int]"; expected "Union[bool, float, int, str, None]"
+spark.read.options(bar={1})  # E: Argument "bar" to "options" of "DataFrameReader" has incompatible type "Set[int]"; expected "Union[bool, float, int, str, None]"
 [out]


### PR DESCRIPTION
With PR #391 `None` has been added as allowed data type for `DataFrameReader/Writer`. This change extends the tests and adapts expected error messages accordingly.

Fixes #397 