### PR TITLE
Add `udf` overload to support decorators with named returnType

### DIFF
--- a/test-data/unit/sql-udf.test
+++ b/test-data/unit/sql-udf.test
@@ -61,18 +61,26 @@ pandas_udf(lambda *xs: 42, "str", PandasUDFType.GROUPED_AGG)
 
 [case legacyUDF]
 from pyspark.sql.functions import udf
+from pyspark.sql.types import IntegerType
 
 udf(lambda x: x, "string")
+
+udf(lambda x: x)
 
 @udf("string")
 def f(x):
     return x
 
 @udf(returnType="string")
-def f(x):
+def g(x):
     return x
 
 @udf(returnType=IntegerType())
-def f(x):
+def h(x):
     return x
+
+@udf
+def i(x):
+    return x
+
 [out]

--- a/test-data/unit/sql-udf.test
+++ b/test-data/unit/sql-udf.test
@@ -67,4 +67,12 @@ udf(lambda x: x, "string")
 @udf("string")
 def f(x):
     return x
+
+@udf(returnType="string")
+def f(x):
+    return x
+
+@udf(returnType=IntegerType())
+def f(x):
+    return x
 [out]

--- a/third_party/3/pyspark/sql/functions.pyi
+++ b/third_party/3/pyspark/sql/functions.pyi
@@ -270,7 +270,7 @@ def udf(
 ) -> Callable[..., Column]: ...
 @overload
 def udf(
-    f: DataTypeOrString = ...,
+    returnType: DataTypeOrString = ...,
 ) -> Callable[[Callable[..., Any]], Callable[..., Column]]: ...
 
 class PandasUDFType:

--- a/third_party/3/pyspark/sql/functions.pyi
+++ b/third_party/3/pyspark/sql/functions.pyi
@@ -274,7 +274,8 @@ def udf(
 ) -> Callable[[Callable[..., Any]], Callable[..., Column]]: ...
 @overload
 def udf(
-    *, returnType: DataTypeOrString = ...,
+    *,
+    returnType: DataTypeOrString = ...,
 ) -> Callable[[Callable[..., Any]], Callable[..., Column]]: ...
 
 class PandasUDFType:

--- a/third_party/3/pyspark/sql/functions.pyi
+++ b/third_party/3/pyspark/sql/functions.pyi
@@ -270,7 +270,11 @@ def udf(
 ) -> Callable[..., Column]: ...
 @overload
 def udf(
-    returnType: DataTypeOrString = ...,
+    f: DataTypeOrString = ...,
+) -> Callable[[Callable[..., Any]], Callable[..., Column]]: ...
+@overload
+def udf(
+    *, returnType: DataTypeOrString = ...,
 ) -> Callable[[Callable[..., Any]], Callable[..., Column]]: ...
 
 class PandasUDFType:


### PR DESCRIPTION
The `udf` decorator accepts `returnType` as an argument